### PR TITLE
HashState streaming actually streams, and matches the single-call templates exactly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BUILDDIR = rain/bin
 WASMDIR = js/wasm
 
 # Sources and Outputs
-SRCS = $(wildcard src/*.cpp)
+SRCS = $(filter-out src/streaming-test.cpp,$(wildcard src/*.cpp))
 OBJS = $(addprefix $(OBJDIR)/,$(notdir $(SRCS:.cpp=.o)))
 DEPS = $(OBJS:.o=.d)
 
@@ -63,6 +63,11 @@ ${WASMDIR}:
 node_modules:
 	@(test ! -d ./js/node_modules && cd js && npm i && cd ..) || :
 	@(test ! -d ./scripts/node_modules && cd scripts && npm i && cd ..) || :
+
+# Streaming-vs-single-call equivalence test (see src/streaming-test.cpp)
+test-streaming: ${BUILDDIR}
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $(BUILDDIR)/streaming-test src/streaming-test.cpp
+	$(BUILDDIR)/streaming-test
 
 # Build Executable (C++ native)
 rainsum: $(OBJS)

--- a/src/rainbow.cpp
+++ b/src/rainbow.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <cstdio>
+#include <algorithm>
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
@@ -74,14 +75,23 @@ namespace rainbow {
     s[1] = b; s[2] = a;
   }
 
-  // Streaming state structure if needed (mirroring your original style)
+  // Streaming state. Semantically IDENTICAL to the single-call rainbow()
+  // below: initialize with the TOTAL input length (the state is length-keyed),
+  // feed the bytes through update() in any chunking, then finalize().
+  // Verified against the single-call path and the published vectors by
+  // src/streaming-test.cpp (make test-streaming).
+  //
+  // History: this struct used to be dead code whose update() ran the
+  // finalization tail on its first call, so a second update() was silently
+  // ignored. Fixed 2026-07-27; the single-call template is unchanged and
+  // remains the definition of the hash.
   struct HashState : IHashState {
     uint64_t  h[4];
     seed_t    seed;
-    size_t    len;
     uint32_t  hashsize;
     bool      inner = false;
-    bool      final_block = false;
+    uint8_t   pending[16];
+    size_t    pending_len = 0;
     bool      finalized = false;
 
     static HashState initialize(const seed_t seed, size_t olen, uint32_t hashsize) {
@@ -93,68 +103,78 @@ namespace rainbow {
       state.len = 0;
       state.seed = seed;
       state.hashsize = hashsize;
+      state.inner = false;
+      state.pending_len = 0;
+      state.finalized = false;
       return state;
     }
 
-    void update(const uint8_t* chunk, size_t chunk_len) {
-      while (chunk_len >= 16) {
-        uint64_t g = GET_U64<false>(chunk, 0);
-
-        h[0] -= g;
-        h[1] += g;
-        chunk += 8;
-
-        g = GET_U64<false>(chunk, 0);
-        h[2] += g;
-        h[3] -= g;
-
-        if (inner) {
-          mixB(h, seed);
-          rotate_right(h);
-        } else {
-          mixA(h);
-        }
-        inner = !inner;
-
-        chunk += 8;
-        chunk_len -= 16;
-        len += 16;
+    void ingest_block(const uint8_t* block) {
+      uint64_t g = GET_U64<false>(block, 0);
+      h[0] -= g;
+      h[1] += g;
+      g = GET_U64<false>(block, 8);
+      h[2] += g;
+      h[3] -= g;
+      if (inner) {
+        mixB(h, seed);
+        rotate_right(h);
+      } else {
+        mixA(h);
       }
+      inner = !inner;
+    }
 
-      // Process any remaining data
-      // According to Frank's logic, if there's any remainder it's the final block
-      if (chunk_len >= 0) {
-        final_block = true;
-        mixB(h, seed);
-
-        switch (chunk_len) {
-          case 15: h[0] += (uint64_t)chunk[14] << 56; // [[fallthrough]];
-          case 14: h[1] += (uint64_t)chunk[13] << 48; // [[fallthrough]]
-          case 13: h[2] += (uint64_t)chunk[12] << 40; // [[fallthrough]]
-          case 12: h[3] += (uint64_t)chunk[11] << 32; // [[fallthrough]]
-          case 11: h[0] += (uint64_t)chunk[10] << 24; // [[fallthrough]]
-          case 10: h[1] += (uint64_t)chunk[9]  << 16; // [[fallthrough]]
-          case  9: h[2] += (uint64_t)chunk[8]  << 8;  // [[fallthrough]]
-          case  8: h[3] += chunk[7];                  //  [[fallthrough]]
-          case  7: h[0] += (uint64_t)chunk[6]  << 48; // [[fallthrough]]
-          case  6: h[1] += (uint64_t)chunk[5]  << 40; // [[fallthrough]]
-          case  5: h[2] += (uint64_t)chunk[4]  << 32; // [[fallthrough]]
-          case  4: h[3] += (uint64_t)chunk[3]  << 24; // [[fallthrough]]
-          case  3: h[0] += (uint64_t)chunk[2]  << 16; // [[fallthrough]]
-          case  2: h[1] += (uint64_t)chunk[1]  <<  8; // [[fallthrough]]
-          case  1: h[2] += (uint64_t)chunk[0];
+    void update(const uint8_t* chunk, size_t chunk_len) {
+      if (finalized) return;
+      this->len += chunk_len;
+      if (pending_len > 0) {
+        size_t take = std::min((size_t)(16 - pending_len), chunk_len);
+        memcpy(pending + pending_len, chunk, take);
+        pending_len += take;
+        chunk += take;
+        chunk_len -= take;
+        if (pending_len == 16) {
+          ingest_block(pending);
+          pending_len = 0;
         }
-
-        mixA(h);
-        mixB(h, seed);
-        mixA(h);
-
-        len += chunk_len;
+      }
+      while (chunk_len >= 16) {
+        ingest_block(chunk);
+        chunk += 16;
+        chunk_len -= 16;
+      }
+      if (chunk_len > 0) {
+        memcpy(pending, chunk, chunk_len);
+        pending_len = chunk_len;
       }
     }
 
     void finalize(void* out) {
       if (finalized) return;
+      // the tail, exactly as the single-call path: mixB, ingest the 0..15
+      // remainder bytes at their length-determined lanes, then mixA/mixB/mixA
+      mixB(h, seed);
+      switch (pending_len) {
+        case 15: h[0] += (uint64_t)pending[14] << 56; // [[fallthrough]]
+        case 14: h[1] += (uint64_t)pending[13] << 48; // [[fallthrough]]
+        case 13: h[2] += (uint64_t)pending[12] << 40; // [[fallthrough]]
+        case 12: h[3] += (uint64_t)pending[11] << 32; // [[fallthrough]]
+        case 11: h[0] += (uint64_t)pending[10] << 24; // [[fallthrough]]
+        case 10: h[1] += (uint64_t)pending[9]  << 16; // [[fallthrough]]
+        case  9: h[2] += (uint64_t)pending[8]  << 8;  // [[fallthrough]]
+        case  8: h[3] += pending[7];                  // [[fallthrough]]
+        case  7: h[0] += (uint64_t)pending[6]  << 48; // [[fallthrough]]
+        case  6: h[1] += (uint64_t)pending[5]  << 40; // [[fallthrough]]
+        case  5: h[2] += (uint64_t)pending[4]  << 32; // [[fallthrough]]
+        case  4: h[3] += (uint64_t)pending[3]  << 24; // [[fallthrough]]
+        case  3: h[0] += (uint64_t)pending[2]  << 16; // [[fallthrough]]
+        case  2: h[1] += (uint64_t)pending[1]  <<  8; // [[fallthrough]]
+        case  1: h[2] += pending[0];
+      }
+      mixA(h);
+      mixB(h, seed);
+      mixA(h);
 
       uint64_t g = 0;
       g -= h[2];

--- a/src/rainstorm.cpp
+++ b/src/rainstorm.cpp
@@ -80,106 +80,99 @@ namespace rainstorm {
   }
   */
 
+  // Streaming state. Semantically IDENTICAL to the single-call rainstorm()
+  // below: initialize with the TOTAL input length (the state is length-keyed),
+  // feed the bytes through update() in any chunking, then finalize().
+  // Verified against the single-call path and the published vectors by
+  // src/streaming-test.cpp (make test-streaming).
+  //
+  // History: this struct used to be dead code with two defects. Its h[2] init
+  // constant duplicated h[1]'s (+2 twice, shifting the sequence to end at +43
+  // where the single-call template ends at +47), and update() ran the
+  // finalization tail on its first call, so a second update() was silently
+  // ignored. Both fixed 2026-07-27; the single-call template — the path the
+  // CLI, the WASM port, and SMHasher3 all use — is unchanged and remains the
+  // definition of the hash.
   struct HashState : IHashState {
-    uint64_t  start[16];
     uint64_t  h[16];
+    uint64_t  temp[8];       // the final rounds mix over the last (padded) block
     seed_t    seed;
-    size_t    len;             
     size_t    olen;
     uint32_t  hashsize;
-    bool      inner = 0;
-    bool      final_block = false;
+    uint8_t   pending[64];
+    size_t    pending_len = 0;
     bool      finalized = false;
 
     static HashState initialize(const seed_t seed, size_t olen, uint32_t hashsize) {
       HashState state;
-
-      state.h[0]  = state.start[0] = seed + olen + 1;
-      state.h[1]  = state.start[1] = seed + olen + 2;
-      state.h[2]  = state.start[2] = seed + olen + 2;
-      state.h[3]  = state.start[3] = seed + olen + 3;
-      state.h[4]  = state.start[4] = seed + olen + 5;
-      state.h[5]  = state.start[5] = seed + olen + 7;
-      state.h[6]  = state.start[6] = seed + olen + 11;
-      state.h[7]  = state.start[7] = seed + olen + 13;
-      state.h[8]  = state.start[8] = seed + olen + 17;
-      state.h[9]  = state.start[9] = seed + olen + 19;
-      state.h[10] = state.start[10] = seed + olen + 23;
-      state.h[11] = state.start[11] = seed + olen + 29;
-      state.h[12] = state.start[12] = seed + olen + 31;
-      state.h[13] = state.start[13] = seed + olen + 37;
-      state.h[14] = state.start[14] = seed + olen + 41;
-      state.h[15] = state.start[15] = seed + olen + 43;
-
-      state.len = 0;  
+      static const uint64_t primes[16] = { 1, 2, 3, 5, 7, 11, 13, 17,
+                                           19, 23, 29, 31, 37, 41, 43, 47 };
+      for (int i = 0; i < 16; i++) {
+        state.h[i] = seed + olen + primes[i];
+      }
+      state.len = 0;
       state.seed = seed;
       state.olen = olen;
       state.hashsize = hashsize;
+      state.pending_len = 0;
+      state.finalized = false;
       return state;
     }
 
-    void update(const uint8_t* chunk, size_t chunk_len) {
-      uint64_t temp[8];
-      if (this->final_block) {
-        // can't update after final block
-        return;
+    void ingest_block(const uint8_t* block) {
+      for (int i = 0, j = 0; i < 8; ++i, j += 8) {
+        temp[i] = GET_U64<false>(block, j);
       }
+      for (int i = 0; i < ROUNDS; i++) {
+        weakfunc(this->h, temp, i & 1);
+      }
+    }
 
+    void update(const uint8_t* chunk, size_t chunk_len) {
+      if (finalized) return;
+      this->len += chunk_len;
+      if (pending_len > 0) {
+        size_t take = std::min((size_t)(64 - pending_len), chunk_len);
+        memcpy(pending + pending_len, chunk, take);
+        pending_len += take;
+        chunk += take;
+        chunk_len -= take;
+        if (pending_len == 64) {
+          ingest_block(pending);
+          pending_len = 0;
+        }
+      }
       while (chunk_len >= 64) {
-        for (int i = 0, j = 0; i < 8; ++i, j += 8) {
-          temp[i] = GET_U64<false>(chunk, j);
-        }
-
-        for (int i = 0; i < ROUNDS; i++) {
-          weakfunc(this->h, temp, i & 1);
-        }
-
-        //compress1(this->h, this->start, seed);
-
+        ingest_block(chunk);
         chunk += 64;
         chunk_len -= 64;
-        this->len += 64;
       }
-
-      if (chunk_len >= 0 || this->olen == 0) {
-        // Pad the remaining data
-        memset(temp, (0x80 + chunk_len) & 255, sizeof(temp));
-        memcpy(temp, chunk, chunk_len);
-        // Frank's fix: Don't perform the length encoding that can cause issues:
-        // temp[lenRemaining >> 3] |= (uint64_t)(lenRemaining << ((lenRemaining&7)*8)); 
-        // was removed in Frank's code.
-
-        //compress1(this->h, this->start, seed);
-
-        for (int i = 0; i < ROUNDS; i++) {
-          weakfunc(this->h, temp, i & 1);
-        }
-
-        for (int i = 0, j = 8; i < 8; i++, j++) {
-          h[i] -= h[j];
-        }
-
-        // If hashsize > 64, do final rounds as Frank does:
-        if (hashsize > 64) {
-          for (int i = 0; i < std::max((int)hashsize / 64, FINAL_ROUNDS); i++) {
-            weakfunc(h, temp, true);
-          }
-        }
-
-        this->len += chunk_len;
-        this->final_block = true;
+      if (chunk_len > 0) {
+        memcpy(pending, chunk, chunk_len);
+        pending_len = chunk_len;
       }
     }
 
     void finalize(void* out) {
-      if (finalized) {
-        return;
+      if (finalized) return;
+      // the tail block: remainder bytes over a (0x80 + remainder)-filled pad,
+      // exactly as the single-call path pads its final block
+      memset(temp, (0x80 + pending_len) & 255, sizeof(temp));
+      memcpy(temp, pending, pending_len);
+      for (int i = 0; i < ROUNDS; i++) {
+        weakfunc(h, temp, i & 1);
       }
-
-      for (int i = 0, j = 0; i < std::min((int)8, (int)this->hashsize / 64); i++, j += 8) {
+      for (int i = 0, j = 8; i < 8; i++, j++) {
+        h[i] -= h[j];
+      }
+      if (hashsize > 64) {
+        for (int i = 0; i < std::max((int)hashsize / 64, FINAL_ROUNDS); i++) {
+          weakfunc(h, temp, true);
+        }
+      }
+      for (uint32_t i = 0, j = 0; i < std::min((uint32_t)8, hashsize / 64); i++, j += 8) {
         PUT_U64<false>(h[i], (uint8_t *)out, j);
       }
-
       finalized = true;
     }
   };

--- a/src/streaming-test.cpp
+++ b/src/streaming-test.cpp
@@ -1,0 +1,127 @@
+// streaming-test — proves HashState streaming equals the single-call
+// templates, for both hashes, every size, many seeds/lengths/chunkings,
+// and anchors rainbow-256/rainstorm-256 seed-0 against two published
+// vectors so the test cannot drift along with the implementation.
+//
+// Build and run: make test-streaming
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "rainbow.cpp"
+#include "rainstorm.cpp"
+
+static int failures = 0;
+
+static std::string hex(const uint8_t* d, size_t n) {
+  static const char* x = "0123456789abcdef";
+  std::string s;
+  for (size_t i = 0; i < n; i++) { s += x[d[i] >> 4]; s += x[d[i] & 15]; }
+  return s;
+}
+
+// deterministic filler so failures reproduce exactly
+static void fill(std::vector<uint8_t>& v) {
+  uint64_t x = 0x9e3779b97f4a7c15ULL;
+  for (size_t i = 0; i < v.size(); i++) {
+    x ^= x << 13; x ^= x >> 7; x ^= x << 17;
+    v[i] = (uint8_t)x;
+  }
+}
+
+template <typename StateT, void SINGLE(const void*, size_t, seed_t, void*)>
+static void check(const char* algo, uint32_t bits, seed_t seed,
+                  const std::vector<uint8_t>& data, size_t chunk) {
+  uint8_t want[64] = {0}, got[64] = {0};
+  SINGLE(data.data(), data.size(), seed, want);
+
+  StateT st = StateT::initialize(seed, data.size(), bits);
+  size_t off = 0;
+  while (off < data.size()) {
+    size_t n = chunk < data.size() - off ? chunk : data.size() - off;
+    st.update(data.data() + off, n);
+    off += n;
+  }
+  if (data.empty()) st.update(data.data(), 0);
+  st.finalize(got);
+
+  if (memcmp(want, got, bits / 8) != 0) {
+    failures++;
+    printf("MISMATCH %s-%u seed=%llu len=%zu chunk=%zu\n  single: %s\n  stream: %s\n",
+           algo, bits, (unsigned long long)seed, data.size(), chunk,
+           hex(want, bits / 8).c_str(), hex(got, bits / 8).c_str());
+  }
+}
+
+static void anchor(const char* algo, const char* input, const char* want_hex) {
+  uint8_t out[32];
+  std::string got;
+  size_t len = strlen(input);
+  if (strcmp(algo, "rainbow") == 0) {
+    auto st = rainbow::HashState::initialize(0, len, 256);
+    st.update((const uint8_t*)input, len);
+    st.finalize(out);
+  } else {
+    auto st = rainstorm::HashState::initialize(0, len, 256);
+    st.update((const uint8_t*)input, len);
+    st.finalize(out);
+  }
+  got = hex(out, 32);
+  if (got != want_hex) {
+    failures++;
+    printf("VECTOR MISMATCH %s-256 \"%s\"\n  want %s\n  got  %s\n", algo, input, want_hex, got.c_str());
+  }
+}
+
+// thin adapters so both templates fit one test harness
+static void rb64(const void* p, size_t n, seed_t s, void* o)  { rainbow::rainbow<64, false>(p, n, s, o); }
+static void rb128(const void* p, size_t n, seed_t s, void* o) { rainbow::rainbow<128, false>(p, n, s, o); }
+static void rb256(const void* p, size_t n, seed_t s, void* o) { rainbow::rainbow<256, false>(p, n, s, o); }
+static void rs64(const void* p, size_t n, seed_t s, void* o)  { rainstorm::rainstorm<64, false>(p, n, s, o); }
+static void rs128(const void* p, size_t n, seed_t s, void* o) { rainstorm::rainstorm<128, false>(p, n, s, o); }
+static void rs256(const void* p, size_t n, seed_t s, void* o) { rainstorm::rainstorm<256, false>(p, n, s, o); }
+static void rs512(const void* p, size_t n, seed_t s, void* o) { rainstorm::rainstorm<512, false>(p, n, s, o); }
+
+int main() {
+  // published vectors (verification/vectors.txt), through the STREAMING path
+  anchor("rainbow",   "", "91fc76841e1431f6d58871e4c981fb37e3c0ac0f9f141c3e99b78f46c727c454");
+  anchor("rainstorm", "", "340b44c7eee5a41f118273c6e1ec519247fa2075266423943dc86b0c8e3cceb9");
+  anchor("rainbow",   "The quick brown fox jumps over the lazy dog",
+         "9c72cf9f50d0f3145ad0f45cf97c09afa6f7555562358dc15c4f4bb14cf2aa85");
+  anchor("rainstorm", "The quick brown fox jumps over the lazy dog",
+         "bf8f3eb749b73705dfb9f2319e0c07a2ee4b2ae5cc36e8a08dbd2bfef7daa4e6");
+
+  const size_t lengths[] = { 0, 1, 15, 16, 17, 43, 63, 64, 65, 127, 128, 129,
+                             1000, 4096, 100000 };
+  const seed_t  seeds[]  = { 0, 1, 42, 0xdeadbeefULL };
+  const size_t  chunks[] = { 1, 7, 16, 63, 64, 65, 1000, (size_t)-1 };
+  int cases = 0;
+
+  for (size_t len : lengths) {
+    std::vector<uint8_t> data(len);
+    fill(data);
+    for (seed_t seed : seeds) {
+      for (size_t chunk : chunks) {
+        size_t c = chunk == (size_t)-1 ? (len ? len : 1) : chunk;
+        check<rainbow::HashState,   rb64 >("rainbow", 64,  seed, data, c);
+        check<rainbow::HashState,   rb128>("rainbow", 128, seed, data, c);
+        check<rainbow::HashState,   rb256>("rainbow", 256, seed, data, c);
+        check<rainstorm::HashState, rs64 >("rainstorm", 64,  seed, data, c);
+        check<rainstorm::HashState, rs128>("rainstorm", 128, seed, data, c);
+        check<rainstorm::HashState, rs256>("rainstorm", 256, seed, data, c);
+        check<rainstorm::HashState, rs512>("rainstorm", 512, seed, data, c);
+        cases += 7;
+      }
+    }
+  }
+
+  if (failures) {
+    printf("streaming-test: %d FAILURE(S) out of %d cases\n", failures, cases);
+    return 1;
+  }
+  printf("streaming-test: all %d cases match the single-call templates (plus 4 published vectors)\n", cases);
+  return 0;
+}


### PR DESCRIPTION
## What

`HashState` (both hashes) was dead code — nothing in rainsum, the WASM port, or SMHasher3 constructs one — and it had two defects:

1. **rainstorm's init constants were `1,2,2,3,…,43`**: `h[2]` duplicated `h[1]`'s `+2`, shifting the whole sequence down a slot and dropping `+47`. The single-call template — the path the CLI (`tool.h` calls `rainstorm::rainstorm<size>` directly), the WASM port, and SMHasher3's copy all use, and the one the published `verification/vectors.txt` describes — is `1,2,3,5,…,47`.
2. **Both structs' `update()` ran the finalization tail on every call**, so a second `update()` was silently ignored (`final_block` was set the first time). Multi-chunk streaming could never have worked.

## The fix

Both `HashState`s now buffer partial blocks and defer the tail to `finalize()`. The single-call templates are **untouched** — they remain the definition of the hash. The `initialize(seed, olen, hashsize)` signature is unchanged: the state is length-keyed, so the total input length is still required up front; "streaming" means feeding the bytes in any chunking.

## Proof

New `src/streaming-test.cpp` + `make test-streaming`:

- **3360 cases**: both algorithms × all sizes (64–512) × 4 seeds × 15 lengths (0…100000) × 8 chunkings (including byte-at-a-time) — streaming digest must equal the single-call digest.
- **4 published vectors** anchored *through the streaming path*, so the test cannot drift along with the implementation.

```
streaming-test: all 3360 cases match the single-call templates (plus 4 published vectors)
```

`make rainsum` still builds and still produces the published vectors (the test .cpp is filtered out of `OBJS` so its `main` doesn't collide).

Found while porting the rain hashes to freelang: the freelang runtime implements the template semantics and matches your vectors on all three of its backends; a future chunked/streaming freelang rainsum needs these HashState semantics as its reference, which is what prompted the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
